### PR TITLE
automake AM_PROG_AR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,8 @@ AM_SILENT_RULES([yes])
 # AM_CONFIG_HEADER([config.h])
 AM_MAINTAINER_MODE()
 
+AM_PROG_AR()
+
 LT_PREREQ([2.2.6])
 LT_INIT([disable-static])
 


### PR DESCRIPTION
Fixed `autogen.sh` error

```
automake: warnings are treated as errors
/usr/share/automake-1.13/am/ltlibrary.am: warning: 'multiload.la': linking libtool libraries using a non-POSIX
/usr/share/automake-1.13/am/ltlibrary.am: archiver requires 'AM_PROG_AR' in 'configure.ac'
lxpanel/Makefile.am:12:   while processing Libtool library 'multiload.la'
...
```

I also [packaged](https://aur.archlinux.org/packages/xfce4-multiload-nandhp-plugin-git/) it for archlinux. I'll be happy switch back to you git if you fix the build
